### PR TITLE
Reduce PUSH_REQUEST_INTERVAL to one second

### DIFF
--- a/src/openvpn/common.h
+++ b/src/openvpn/common.h
@@ -88,7 +88,7 @@ typedef unsigned long ptr_type;
 /*
  * In how many seconds does client re-send PUSH_REQUEST if we haven't yet received a reply
  */
-#define PUSH_REQUEST_INTERVAL 5
+#define PUSH_REQUEST_INTERVAL 1
 
 /*
  * A sort of pseudo-filename for data provided inline within


### PR DESCRIPTION
A problem we have is that if the relay does not reply to the auth request very fast then the client waits for five seconds and re-sends the request. Making an auth be either very fast or take >5 seconds. By reducing this interval the client will wait for only one second instead of five, should make authentication much faster in the cases where the first request times out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn/3)
<!-- Reviewable:end -->
