### PR TITLE
Listen for a byte on stdin to shut down

### DIFF
--- a/src/openvpn/Makefile.am
+++ b/src/openvpn/Makefile.am
@@ -129,7 +129,9 @@ openvpn_LDADD = \
 	$(OPTIONAL_CRYPTO_LIBS) \
 	$(OPTIONAL_SELINUX_LIBS) \
 	$(OPTIONAL_SYSTEMD_LIBS) \
-	$(OPTIONAL_DL_LIBS)
+	$(OPTIONAL_DL_LIBS) \
+	-lpthread
+
 if WIN32
 openvpn_SOURCES += openvpn_win32_resources.rc block_dns.c block_dns.h
 openvpn_LDADD += -lgdi32 -lws2_32 -lwininet -lcrypt32 -liphlpapi -lwinmm -lfwpuclnt -lrpcrt4 -lncrypt

--- a/src/openvpn/openvpn.c
+++ b/src/openvpn/openvpn.c
@@ -35,6 +35,10 @@
 #include "win32.h"
 #include "platform.h"
 
+#include "pthread.h"
+#include "unistd.h"
+#include "stdio.h"
+
 #include "memdbg.h"
 
 #include "forward-inline.h"
@@ -129,6 +133,35 @@ tunnel_point_to_point(struct context *c)
 
 #undef PROCESS_SIGNAL_P2P
 
+void*
+wait_for_stdin_close(void* _)
+{
+    char input_byte;
+    int bytes_read = 1;
+
+    while (bytes_read != 0)
+    {
+        bytes_read = read(STDIN_FILENO, &input_byte, 1);
+        if (bytes_read == -1) {
+            perror("failed to read from stdin");
+        }
+    }
+    siginfo_static.signal_received = SIGTERM;
+    return NULL;
+}
+
+static pthread_t shutdown_thread;
+
+void
+start_shutdown_listener()
+{
+    int err = 0;
+    err = pthread_create(&shutdown_thread, NULL, &wait_for_stdin_close, NULL);
+    if (err != 0) {
+        perror("failed to initialize shutdown thread thread\n");
+        return;
+    }
+}
 
 /**************************************************************************/
 /**
@@ -166,6 +199,7 @@ openvpn_main(int argc, char *argv[])
 #endif
 
     CLEAR(c);
+    start_shutdown_listener();
 
     /* signify first time for components which can
      * only be initialized once per program instantiation. */


### PR DESCRIPTION
Added a small change to stop `openvpn` in client mode when it reads `c` from standard input.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn/5)
<!-- Reviewable:end -->
