### PR TITLE
Server auth failed event

### DIFF
--- a/src/openvpn/ssl.c
+++ b/src/openvpn/ssl.c
@@ -1017,6 +1017,7 @@ key_state_free(struct key_state *ks, bool clear)
 
 #ifdef PLUGIN_DEF_AUTH
     key_state_rm_auth_control_file(ks);
+    key_state_rm_auth_failure_reason_file(ks);
 #endif
 
     if (clear)
@@ -1349,8 +1350,8 @@ tls_multi_free(struct tls_multi *multi, bool clear)
 
     ASSERT(multi);
 
-#ifdef MANAGEMENT_DEF_AUTH
-    man_def_auth_set_client_reason(multi, NULL);
+#ifdef ENABLE_DEF_AUTH
+    tls_def_auth_set_client_reason(multi, NULL);
 
 #endif
 #if P2MP_SERVER

--- a/src/openvpn/ssl_common.h
+++ b/src/openvpn/ssl_common.h
@@ -199,6 +199,7 @@ struct key_state
     unsigned int auth_control_status;
     time_t acf_last_mod;
     char *auth_control_file;
+    char *auth_failure_reason_file;
 #endif
 #endif
 };

--- a/src/openvpn/ssl_verify.h
+++ b/src/openvpn/ssl_verify.h
@@ -98,6 +98,13 @@ int tls_authentication_status(struct tls_multi *multi, const int latency);
 void key_state_rm_auth_control_file(struct key_state *ks);
 
 /**
+ * Remove the given key state's auth failure reason file, if it exists.
+ *
+ * @param ks    The key state the remove the file for
+ */
+void key_state_rm_auth_failure_reason_file(struct key_state *ks);
+
+/**
  * Frees the given set of certificate hashes.
  *
  * @param chs   The certificate hash set to free.
@@ -225,9 +232,10 @@ struct x509_track
  */
 #ifdef MANAGEMENT_DEF_AUTH
 bool tls_authenticate_key(struct tls_multi *multi, const unsigned int mda_key_id, const bool auth, const char *client_reason);
+#endif
 
-void man_def_auth_set_client_reason(struct tls_multi *multi, const char *client_reason);
-
+#ifdef ENABLE_DEF_AUTH
+void tls_def_auth_set_client_reason(struct tls_multi *multi, const char *client_reason);
 #endif
 
 static inline const char *


### PR DESCRIPTION
For the server side we only want the needed changes for the auth-fail message, to prevent any other unforeseen issues that might arise from using the other patches the client uses.

Please verify that I've correctly added only the needed changes for auth-fail to work and nothing else.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn/6)
<!-- Reviewable:end -->
