### PR TITLE
Change openvpn dir, disable logging and home protection for systemd s…

### DIFF
--- a/distro/systemd/openvpn-client@.service.in
+++ b/distro/systemd/openvpn-client@.service.in
@@ -9,15 +9,17 @@ Documentation=https://community.openvpn.net/openvpn/wiki/HOWTO
 [Service]
 Type=notify
 PrivateTmp=true
-WorkingDirectory=/etc/openvpn/client
-ExecStart=@sbindir@/openvpn --suppress-timestamps --nobind --config %i.conf
+WorkingDirectory=/etc/openvpn
+ExecStart=@sbindir@/openvpn --nobind --config %i.conf
 CapabilityBoundingSet=CAP_IPC_LOCK CAP_NET_ADMIN CAP_NET_RAW CAP_SETGID CAP_SETUID CAP_SYS_CHROOT CAP_DAC_OVERRIDE
 LimitNPROC=10
 DeviceAllow=/dev/null rw
 DeviceAllow=/dev/net/tun rw
 ProtectSystem=true
-ProtectHome=true
+ProtectHome=false
 KillMode=process
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=multi-user.target

--- a/distro/systemd/openvpn-server@.service.in
+++ b/distro/systemd/openvpn-server@.service.in
@@ -9,17 +9,19 @@ Documentation=https://community.openvpn.net/openvpn/wiki/HOWTO
 [Service]
 Type=notify
 PrivateTmp=true
-WorkingDirectory=/etc/openvpn/server
-ExecStart=@sbindir@/openvpn --status %t/openvpn-server/status-%i.log --status-version 2 --suppress-timestamps --config %i.conf
+WorkingDirectory=/etc/openvpn
+ExecStart=@sbindir@/openvpn --config %i.conf
 CapabilityBoundingSet=CAP_IPC_LOCK CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_SETGID CAP_SETUID CAP_SYS_CHROOT CAP_DAC_OVERRIDE
 LimitNPROC=10
 DeviceAllow=/dev/null rw
 DeviceAllow=/dev/net/tun rw
 ProtectSystem=true
-ProtectHome=true
+ProtectHome=false
 KillMode=process
 RestartSec=5s
 Restart=on-failure
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Changing working directory to user `/etc/openvpn`, we detect if it's a client or server in other ways. We also stripped all options used for logging from the execution and set stdout and stderr to write to `/dev/null`. Lastly, we disable read-only `/home` since we need to create sockets there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn/7)
<!-- Reviewable:end -->
